### PR TITLE
Develop

### DIFF
--- a/src/application/App.java
+++ b/src/application/App.java
@@ -10,6 +10,11 @@ public class App {
 		//At this point there is no closing of the db, and 
 		//the program doesn't warn about it either
 		
+		/*once AutoCloseable interface is added to Database class
+		 * now get a warning about a resource leak cause the db isn't closed
+		 */
 		
+		db.close();
+		//this removes the resource leak warning
 	}
 }

--- a/src/application/App.java
+++ b/src/application/App.java
@@ -3,6 +3,13 @@ package application;
 public class App {
 
 	public static void main(String[] args) {
+		Database db = new Database("localhost:3306");
+		
+		db.getData();
+		
+		//At this point there is no closing of the db, and 
+		//the program doesn't warn about it either
+		
 		
 	}
 }

--- a/src/application/Database.java
+++ b/src/application/Database.java
@@ -1,0 +1,23 @@
+package application;
+
+public class Database {
+	private String connectionString;
+	/* when connecting to a DB, usually have a connection string
+	 * that has the info for connecting to the DB.  And usually have 
+	 * a close method to close the connection as well.
+	 */
+	
+	public Database(String connectionString) {
+		System.out.println("Opening connection to " + connectionString);
+		this.connectionString = connectionString;
+	}
+	
+	public void getData() {
+		System.out.println("Getting data from " + connectionString);
+	}
+	
+	public void close() {
+		System.out.println("Closing connection....");
+	}
+	
+}

--- a/src/application/Database.java
+++ b/src/application/Database.java
@@ -1,6 +1,6 @@
 package application;
 
-public class Database {
+public class Database implements AutoCloseable {
 	private String connectionString;
 	/* when connecting to a DB, usually have a connection string
 	 * that has the info for connecting to the DB.  And usually have 


### PR DESCRIPTION
Set up a simple program with a DB connection to show that close() is not really caught by Java, although Eclipse does give a warning about a resource leak.  Implemented the AutoCloseable interface, which removes the warning.